### PR TITLE
Publish .d.ts; don't build if cached

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -11,20 +11,21 @@ jobs:
 
       - uses: jdx/mise-action@v2
 
+      - name: Cache check
+        id: cache-check
+        uses: actions/cache@v4
+        with:
+          path: pkg
+          key: wasm-build-${{ github.ref_name }}-${{ hashFiles('src/**', 'Cargo.lock') }}-1
+
       - name: Build WASM binary
+        if: steps.cache-check.outputs.cache-hit != 'true'
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             mise run build -- --release
           else
             mise run build -- --dev
           fi
-
-      - name: Cache check
-        id: cache-check
-        uses: actions/cache@v4
-        with:
-          path: pkg
-          key: wasm-build-${{ github.ref_name }}-${{ hashFiles('src/**', 'Cargo.lock') }}
 
       - name: Upload WASM artifacts
         if: steps.cache-check.outputs.cache-hit != 'true'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,6 +40,7 @@ jobs:
           files: |
             *.wasm
             *.js
+            *.d.ts
           tag_name: v${{ github.run_number }}
           name: Release v${{ github.run_number }}
           draft: false


### PR DESCRIPTION
Didn't publish the `*.d.ts` files of the wasm tool itself, so I've added those. 